### PR TITLE
Added bottom nav and app layout shell for main routes

### DIFF
--- a/web/src/app/(main)/dashboard/page.tsx
+++ b/web/src/app/(main)/dashboard/page.tsx
@@ -1,0 +1,3 @@
+export default function DashboardPage() {
+  return <div className="p-6">Dashboard coming soon</div>;
+}

--- a/web/src/app/(main)/discover/page.tsx
+++ b/web/src/app/(main)/discover/page.tsx
@@ -1,0 +1,3 @@
+export default function DiscoverPage() {
+  return <div className="p-6">Discover coming soon</div>;
+}

--- a/web/src/app/(main)/events/page.tsx
+++ b/web/src/app/(main)/events/page.tsx
@@ -1,0 +1,3 @@
+export default function EventsPage() {
+  return <div className="p-6">Events coming soon</div>;
+}

--- a/web/src/app/(main)/explore/page.tsx
+++ b/web/src/app/(main)/explore/page.tsx
@@ -1,0 +1,3 @@
+export default function ExplorePage() {
+  return <div className="p-6">Explore coming soon</div>;
+}

--- a/web/src/app/(main)/layout.tsx
+++ b/web/src/app/(main)/layout.tsx
@@ -1,0 +1,14 @@
+import BottomNav from "@/components/layout/BottomNav";
+
+export default function MainLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <div className="min-h-screen pb-16 md:pb-0">
+      <main>{children}</main>
+      <BottomNav />
+    </div>
+  );
+}

--- a/web/src/app/(main)/matches/page.tsx
+++ b/web/src/app/(main)/matches/page.tsx
@@ -1,0 +1,3 @@
+export default function MatchesPage() {
+  return <div className="p-6">Matches coming soon</div>;
+}

--- a/web/src/app/(main)/profile/page.tsx
+++ b/web/src/app/(main)/profile/page.tsx
@@ -1,0 +1,3 @@
+export default function ProfilePage() {
+  return <div className="p-6">Profile coming soon</div>;
+}

--- a/web/src/components/layout/BottomNav.tsx
+++ b/web/src/components/layout/BottomNav.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const tabs = [
+  { href: "/discover", icon: "❤️", label: "Discover" },
+  { href: "/matches", icon: "💬", label: "Matches" },
+  { href: "/explore", icon: "📍", label: "Explore" },
+  { href: "/events", icon: "📅", label: "Events" },
+  { href: "/profile", icon: "👤", label: "Profile" },
+];
+
+export default function BottomNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 z-50 border-t border-[#E8DDD0] bg-white md:hidden">
+      <ul className="grid grid-cols-5">
+        {tabs.map((tab) => {
+          const isActive =
+            pathname === tab.href || pathname.startsWith(`${tab.href}/`);
+
+          return (
+            <li key={tab.href}>
+              <Link
+                href={tab.href}
+                className={`flex flex-col items-center justify-center py-2 text-xs font-medium ${
+                  isActive ? "text-[#E8734A]" : "text-gray-500"
+                }`}
+              >
+                <span className="text-lg leading-none">{tab.icon}</span>
+                <span>{tab.label}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}


### PR DESCRIPTION
The common app layout and mobile bottom navigation for the primary logged-in routes are added by this PR. To make the new navigation links functional and testable, I made placeholder pages for the dashboard, discover, matches, explore, events, and profile. On desktop, the bottom navigation is hidden and the current tab can be seen in coral.